### PR TITLE
Trim trailing blank lines and spaces for custom filter

### DIFF
--- a/pkg/controller.go
+++ b/pkg/controller.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -163,7 +164,9 @@ func (r *Controller) FilterObject(obj *unstructured.Unstructured) (bool, error) 
 			return true, executeErr
 		}
 
-		if string(result) != r.watcher.Spec.Filter.Object.Custom.Result {
+		actual := string(result)
+		expected := r.watcher.Spec.Filter.Object.Custom.Result
+		if strings.TrimSpace(actual) != strings.TrimSpace(expected) {
 			return true, nil
 		}
 	}

--- a/pkg/controller.go
+++ b/pkg/controller.go
@@ -157,16 +157,15 @@ func (r *Controller) FilterObject(obj *unstructured.Unstructured) (bool, error) 
 		return true, nil
 	}
 
-	if r.watcher.Spec.Filter.Object.Custom != nil {
-		result, executeErr := common.TemplateExecuteForObject(
-			r.watcher.Spec.Filter.Object.Custom.Compiled.Template, obj)
+	if customFilter := r.watcher.Spec.Filter.Object.Custom; customFilter != nil {
+		renderedResult, executeErr := common.TemplateExecuteForObject(
+			customFilter.Compiled.Template, obj)
 		if executeErr != nil {
 			return true, executeErr
 		}
 
-		actual := string(result)
-		expected := r.watcher.Spec.Filter.Object.Custom.Result
-		if strings.TrimSpace(actual) != strings.TrimSpace(expected) {
+		actual := string(renderedResult)
+		if strings.TrimSpace(actual) != strings.TrimSpace(customFilter.Result) {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
YAML literal with the following template produces new line at the end of the result.
```
      custom:
        template: |
          {{- if and .status.conditions (gt (len .status.conditions) 0) }}true{{ end }}
        result: "true"
```
Although `>-`, `|-` "strip" removes the trailing blank lines, it also destroys the formatting.

Would be nice to strip the result and the expected string as well, to make the Watcher more user friendly.

I hope it is not cause more confusion then improve the actual code. 

